### PR TITLE
fix: Mac, Window 호환 가능한 외장하드 메타파일 삭제 코드 추가

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "seed": "pnpm run prisma:generate && dotenv -e ./env/.env.development -- node ./scripts/seed.js",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "predev": "node -e \"import fs from 'fs'; const p = 'node_modules'; if (fs.existsSync(p)) fs.readdirSync(p).forEach(f => { if (f.startsWith('._')) fs.rmSync(p + '/' + f, { recursive: true, force: true }) })\""
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
## 변경 유형

- [ ] 새로운 기능 (New Feature)
- [ ] 버그 수정 (Bug Fix)
- [ ] 코드 리팩토링 (Refactoring)
- [ ] 문서 수정 (Documentation)
- [ ] 테스트 추가 (Test)
- [x] 기타 (Other)

## 변경 사항

fix: Mac, Window 호환 가능한 외장하드 메타파일 삭제 코드 추가

package.json의 script에

"predev": "node -e \"import fs from 'fs'; const p = 'node_modules'; if (fs.existsSync(p)) fs.readdirSync(p).forEach(f => { if (f.startsWith('._')) fs.rmSync(p + '/' + f, { recursive: true, force: true }) })\""

코드 추가함.
 

## 체크리스트

- [ ] 코드가 정상적으로 동작하는지 확인했습니다
- [x] 기존 기능에 영향을 주지 않는지 확인했습니다
- [ ] 필요한 경우 문서를 업데이트했습니다

## 관련 이슈

